### PR TITLE
[PublicHealth Hub] Public Health 142 Library Updates

### DIFF
--- a/deployments/publichealth/image/r-packages/ph-142.r
+++ b/deployments/publichealth/image/r-packages/ph-142.r
@@ -20,7 +20,8 @@ class_libs = c(
   "cowplot", "1.1.1",
   "patchwork", "1.1.1",
   "tigris", "1.0",
-  "googlesheets4", "0.2.0"
+  "googlesheets4", "1.0.0",
+  "coxed", "0.3.3"
 )
 
 print("Installing ottr...")


### PR DESCRIPTION
- Update `googlesheets4` to version 1.0.0
- Install `coxed` version 0.3.3